### PR TITLE
Added Alert component to docs

### DIFF
--- a/docs/features/schema/api.md
+++ b/docs/features/schema/api.md
@@ -3,10 +3,12 @@ id: api
 title: API documentation
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/api.md
 ---
+import Alert from '../../../../developer-site/src/components/Alert';
 
-## NOTICE
+<Alert>
 
 The release of [Yoast SEO 14.0](https://developer.yoast.com/upcoming-release-yoast-seo-14-0-indexables/) in April 2020 brings significant changes to how our Schema API and integration mechanics work. This document reflects our API *after* that release.
+</Alert>
 
 ## Making Schema easier to debug
 If you're working on Schema, it can be rather hard to read. To change that, you should toggle the `yoast_seo_development_mode` filter to `true`. At that point all the Schema that Yoast SEO outputs will be pretty printed. 

--- a/docs/features/schema/integration-guidelines.md
+++ b/docs/features/schema/integration-guidelines.md
@@ -3,12 +3,17 @@ id: integration-guidelines
 title: Integration guidelines
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/xml-sitemaps.md
 ---
+import Alert from '../../../../developer-site/src/components/Alert';
 
-## NOTICE
+<Alert>
 
 The release of [Yoast SEO 14.0](https://developer.yoast.com/upcoming-release-yoast-seo-14-0-indexables/) in April 2020 brings significant changes to how our Schema API and integration mechanics work. This document reflects our API *after* that release.
+</Alert>
+
+<Alert>
 
 This page will be updated with up-do-date information in the near future. If you have any questions, or want to get a head start, you can find our release announcements and technical documentation [here](https://developer.yoast.com/upcoming-release-yoast-seo-14-0-indexables/).
+</Alert>
 
 ## Introduction
 

--- a/docs/yoast-seo-product-sheet.md
+++ b/docs/yoast-seo-product-sheet.md
@@ -3,7 +3,7 @@ id: yoast-seo-product-sheet
 title: Yoast SEO Product sheet
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/yoast-seo-product-sheet.md
 ---
-import useBaseUrl from '@docusaurus/useBaseUrl'; // Add to the top of the file below the front matter.
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import YoastSchemaExample from '../../developer-site/src/components/YoastSchemaExample';
 
 This document is a living document, describing the functionality of Yoast SEO for any platform. 


### PR DESCRIPTION
This PR introduces the usage of the Alert component instead of a separate header section.

Requires: https://github.com/Yoast/developer-site/pull/21/files