### PR TITLE
Removed bullet point from technical SEO section

### DIFF
--- a/docs/yoast-seo-product-sheet.md
+++ b/docs/yoast-seo-product-sheet.md
@@ -19,7 +19,6 @@ Some things need to work out of the box when the module is enabled.
 
 * The site needs to have pretty permalinks. System permalinks should refer to their human-readable equivalents through canonicals.
 * Every page needs to have a rel="canonical" that defaults to its generated pretty URL. See [rel=canonical: the ultimate guide](https://yoast.com/rel-canonical/) on Yoast.com.
-* The site needs to handle paginated content well. Paginated content should have `rel="next"` and/or `rel="prev"` tags. See [Google's documentation on paginated content](https://support.google.com/webmasters/answer/1663744?hl=en).
 * Search results and archive pages that should be public should have meta robots tags `noindex, follow`.
 * Category pages which are paginated should index all pages in the series (previous advice suggested that only the first page should be indexed).
 


### PR DESCRIPTION
Removed bullet point regarding `rel=next`/`rel=prev` as it contains a broken link and seems to no longer be relevant.