### PR TITLE
Altered the ID and fixed a minor bug in the overview doc

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,5 +1,5 @@
 ---
-id: overview
+id: _index
 title: Overview
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/overview.md
 ---
@@ -16,7 +16,7 @@ Learn how our features work, how to customize the outputs, and how best to integ
   - [Canonical URLs](features/seo-tags/canonical-urls/overview.md)
   - [Meta robots tags](features/seo-tags/meta-robots/overview.md)
 - [OpenGraph tags](features/opengraph/overview.md)
-  [Twitter tags](features/twitter/functional-specification.md)
+- [Twitter tags](features/twitter/functional-specification.md)
 - [Schema.org markup](features/schema/overview.md)
   - [Schema pieces](/features/schema/pieces.md)
   - [Output per plugin](/features/schema/plugins.md)


### PR DESCRIPTION
The change of ID is on purpose, as per https://v2.docusaurus.io/docs/docs-introduction/#home-page-docs

Requires https://github.com/Yoast/developer-site/pull/54