### PR TITLE
Initial docs for HTTP headers

### DIFF
--- a/docs/features/http-headers/api.md
+++ b/docs/features/http-headers/api.md
@@ -1,8 +1,0 @@
----
-id: api
-title: HTTP Headers - API documentation
-sidebar_label: HTTP Headers
-custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/http-headers/api.md
-description: Instructions on how to modify our HTTP headers programmatically.
----
-Coming soon.

--- a/docs/features/http-headers/functional-specification.md
+++ b/docs/features/http-headers/functional-specification.md
@@ -5,4 +5,14 @@ sidebar_label: Specification
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/http-headers/functional-specification.md
 description: An overview of how HTTP headers work in Yoast SEO.
 ---
-Coming soon.
+Yoast SEO constructs and optimizes various HTTP headers, in order to manage indexing, assist with debugging, and compliment other functionality.
+
+## x-robots-tag
+It's sometimes desirable to prevent 'non-page' resources (resources like PDFs or XML files, which don't support HTML `<head>` mark-up) from being crawled or indexed by search engines.
+When the content management system serves these resources, we can manipulate their HTTP headers to provide crawl and indexing directives via an `x-robots-tag` HTTP header.
+
+We do this in the following cases:
+- All XML sitemaps return a `noindex, follow` directive. *NB, this does not affect sitemap consumption or processing.*
+
+## x-redirected-by
+When our redirect manager executes a redirect, we pass a value of 'Yoast SEO Premium' to WordPress' `wp_redirect()` function. This adds a `x-redirected-by` header to the response, which can be helpful when debugging.

--- a/docs/features/http-headers/functional-specification.md
+++ b/docs/features/http-headers/functional-specification.md
@@ -13,6 +13,7 @@ When the content management system serves these resources, we can manipulate the
 
 We do this in the following cases:
 - All XML sitemaps return a `noindex, follow` directive. *NB, this does not affect sitemap consumption or processing.*
+- XMLRPC files return a `noindex, follow` directive.
 
 ## x-redirected-by
 When our redirect manager executes a redirect, we pass a value of 'Yoast SEO Premium' to WordPress' `wp_redirect()` function. This adds a `x-redirected-by` header to the response, which can be helpful when debugging.

--- a/docs/features/http-headers/overview.md
+++ b/docs/features/http-headers/overview.md
@@ -9,4 +9,3 @@ This documentation provides technical information about how [Yoast SEO](https://
 
 ## Resources
 * Our [functional specification](functional-specification.md) describes the logic we use to construct and output HTTP headers in various conditions.
-* Our [API documentation](api.md) [coming soon] provides examples of how technical users and developers can modify the default behavior.


### PR DESCRIPTION
Documented some HTTP header behaviour, and removed the API page from this section.