### PR TITLE
Updates docs to fully utilize alpha 62 features

### DIFF
--- a/docs/customization/local-seo/changing-location-post-type.md
+++ b/docs/customization/local-seo/changing-location-post-type.md
@@ -4,7 +4,7 @@ title: Local SEO - Changing the default Location post type
 sidebar_label: Changing the default Location post type
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/customization/local-seo/changing-location-post-type.md
 ---
-import Alert from '../../../../developer-site/src/components/Alert';
+import Alert from '@site/src/components/Alert';
 
 As of version 13.2, you or your developer can change the default locations post type with the `wpseo_local_post_type` filter. This filter takes a single parameter: `$post_type` (required).
 This filter is particularly useful in cases where you have defined a custom post type that you're using for your locations.

--- a/docs/customization/yoast-seo/indexables-cli.md
+++ b/docs/customization/yoast-seo/indexables-cli.md
@@ -4,7 +4,7 @@ title: Yoast SEO - Indexables CLI command
 sidebar_label: Indexables CLI command
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/customization/yoast-seo/indexables-cli.md
 ---
-import Alert from '../../../../developer-site/src/components/Alert';
+import Alert from '@site/src/components/Alert';
 
 With the introduction of Yoast SEO 14.0, we've introduced new database tables in which we combine all the metadata for indexable objects on a site. 
 However, these database tables also need to be filled with data before they can be properly used. To do this efficiently on large sites, we've introduced a WP CLI command.

--- a/docs/features/schema/api.md
+++ b/docs/features/schema/api.md
@@ -5,7 +5,7 @@ sidebar_label: Schema API
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/api.md
 description: Instructions on how to modify our schema output programmatically.
 ---
-import Alert from '../../../../developer-site/src/components/Alert';
+import Alert from '@site/src/components/Alert';
 
 <Alert>
 

--- a/docs/features/schema/functional-specification.md
+++ b/docs/features/schema/functional-specification.md
@@ -5,7 +5,7 @@ sidebar_label: Specification
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/specification.md
 description: This page describes our functional and technical approach to constructing schema.org markup.
 ---
-import YoastSchemaExample from '../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 The core of our approach is to output a "base script" - a `@graph` object rendered in `JSON-LD` - which describes the `WebPage`, the `WebSite`, and the `Organization` (or `Person`, in the case of a website which represents an individual). This is included on every page of a website running the [Yoast SEO plugin](https://yoast.com/wordpress/plugins/seo/) .
 

--- a/docs/features/schema/pieces/aggregateoffer.md
+++ b/docs/features/schema/pieces/aggregateoffer.md
@@ -5,7 +5,7 @@ sidebar_label: AggregateOffer
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/aggregateoffer.md
 description: Describes a group of 'offers' for a 'Product', typically due to variations in attributes (colors, sizes, prices).
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes a group of `offers` for a `Product`, typically due to variations in attributes (colors, sizes, prices).
 

--- a/docs/features/schema/pieces/article.md
+++ b/docs/features/schema/pieces/article.md
@@ -5,7 +5,7 @@ sidebar_label: Article
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/article.md
 description: Describes an 'Article' on a 'WebPage'.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes an `Article` on a `WebPage`.
 May be transformed into a more specific type (such as `NewsArticle`) if the required conditions are met.

--- a/docs/features/schema/pieces/breadcrumb.md
+++ b/docs/features/schema/pieces/breadcrumb.md
@@ -5,7 +5,7 @@ sidebar_label: Breadcrumb
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/breadcrumb.md
 description: Describes the hierarchical position a 'WebPage' within a 'WebSite'.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes the hierarchical position a `WebPage` within a `WebSite`.
 

--- a/docs/features/schema/pieces/comment.md
+++ b/docs/features/schema/pieces/comment.md
@@ -5,7 +5,7 @@ sidebar_label: Comment
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/comment.md
 description: Describes a review. Usually in the context of an 'Article' or a 'WebPage'.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes a review. Usually in the context of an `Article` or a `WebPage`.
 

--- a/docs/features/schema/pieces/howto.md
+++ b/docs/features/schema/pieces/howto.md
@@ -5,7 +5,7 @@ sidebar_label: HowTo
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/howto.md
 description: Describes a 'HowTo' guide, which contains a series of 'steps'.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes a `HowTo` guide, which contains a series of `steps`.
 

--- a/docs/features/schema/pieces/image.md
+++ b/docs/features/schema/pieces/image.md
@@ -5,7 +5,7 @@ sidebar_label: Image (ImageObject)
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/image.md
 description: Describes an individual image (usually in the context of an embedded media object).
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes an individual image (usually in the context of an embedded media object).
 

--- a/docs/features/schema/pieces/localbusiness.md
+++ b/docs/features/schema/pieces/localbusiness.md
@@ -5,7 +5,7 @@ sidebar_label: LocalBusiness
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/localbusiness.md
 description: Describes a business which allows public visitation. Typically used to represent the business 'behind' the website, or on a page about a specific business.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes a business which allows public visitation. Typically used to represent the business 'behind' the website, or on a page about a specific business.
 

--- a/docs/features/schema/pieces/offer.md
+++ b/docs/features/schema/pieces/offer.md
@@ -5,7 +5,7 @@ sidebar_label: Offer
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/offer.md
 description: Describes an offer for a 'Product' (typically prices, stock availability, etc).
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes an offer for a `Product` (typically prices, stock availability, etc).
 

--- a/docs/features/schema/pieces/organization.md
+++ b/docs/features/schema/pieces/organization.md
@@ -5,7 +5,7 @@ sidebar_label: Organization
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/organization.md
 description: Describes an organization (a company, business or institution). Most commonly used to identify the publisher of a 'WebSite'.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes an organization (a company, business or institution). Most commonly used to identify the publisher of a `WebSite`.
 

--- a/docs/features/schema/pieces/person.md
+++ b/docs/features/schema/pieces/person.md
@@ -5,7 +5,7 @@ sidebar_label: Person
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/person.md
 description: Describes an individual person. Most commonly used to identify the 'author' of a piece of content.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes an individual person. Most commonly used to identify the `author` of a piece of content (such as an `Article` or `Comment`).
 

--- a/docs/features/schema/pieces/postaladdress.md
+++ b/docs/features/schema/pieces/postaladdress.md
@@ -5,7 +5,7 @@ sidebar_label: Postal Address
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/postaladdress.md
 description: Describes the postal address of a place; usually in the context of a 'LocalBusiness'.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes the postal address of a place; usually in the context of a `LocalBusiness`.
 

--- a/docs/features/schema/pieces/product.md
+++ b/docs/features/schema/pieces/product.md
@@ -5,7 +5,7 @@ sidebar_label: Product
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/product.md
 description: Describes a product sold by a business.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes a product sold by a business.
 

--- a/docs/features/schema/pieces/question.md
+++ b/docs/features/schema/pieces/question.md
@@ -5,7 +5,7 @@ sidebar_label: Question
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/question.md
 description: Describes a 'Question'. Most commonly used in 'FAQPage' or 'QAPage' content.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes a `Question`. Most commonly used in `FAQPage` or `QAPage` content.
 

--- a/docs/features/schema/pieces/recipe.md
+++ b/docs/features/schema/pieces/recipe.md
@@ -5,7 +5,7 @@ sidebar_label: Recipe
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/recipe.md
 description: Describes a 'Recipe', which contains a series of instructions, ingredients, and optional fields.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes a `Recipe`, which contains a series of instructions, ingredients, and optional fields.
 

--- a/docs/features/schema/pieces/review.md
+++ b/docs/features/schema/pieces/review.md
@@ -5,7 +5,7 @@ sidebar_label: Review
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/review.md
 description: Describes a 'Review'. Usually in the context of a 'Product' or an 'Organization'.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes a `Review`. Usually in the context of a `Product` or an `Organization`.
 

--- a/docs/features/schema/pieces/searchaction.md
+++ b/docs/features/schema/pieces/searchaction.md
@@ -5,7 +5,7 @@ sidebar_label: SearchAction
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/searchaction.md
 description: Describes a 'SearchAction' on a 'WebSite'.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes a `SearchAction` on a `WebSite`.
 

--- a/docs/features/schema/pieces/video.md
+++ b/docs/features/schema/pieces/video.md
@@ -5,7 +5,7 @@ sidebar_label: Video (VideoObject)
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/video.md
 description: Describes an individual video (usually in the context of an embedded media object).
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes an individual video (usually in the context of an embedded media object).
 

--- a/docs/features/schema/pieces/webpage.md
+++ b/docs/features/schema/pieces/webpage.md
@@ -5,7 +5,7 @@ sidebar_label: WebPage
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/webpage.md
 Description: Describes a single page on a 'WebSite'. Acts as a container for sub-page elements (such as 'Article').
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes a single page on a `WebSite`. Acts as a container for sub-page elements (such as `Article`).
 

--- a/docs/features/schema/pieces/website.md
+++ b/docs/features/schema/pieces/website.md
@@ -5,7 +5,7 @@ sidebar_label: WebSite
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/pieces/website.md
 description: Describes a 'WebSite'. Parent to 'WebPage'.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 Describes a `WebSite`. Parent to `WebPage`.
 

--- a/docs/features/schema/plugins/local-seo.md
+++ b/docs/features/schema/plugins/local-seo.md
@@ -5,7 +5,7 @@ sidebar_label: Local SEO for WordPress
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/plugins/local-seo.md
 description: Describes the schema output of Yoast's "Local SEO" plugin for WordPress.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 The schema output for [Local SEO for WordPress](https://yoast.com/wordpress/plugins/local-seo/) builds upon [Yoast SEO for WordPress' base schema output](yoast-seo.md), to add additional *local business* detail (such as addresses and opening hours).
 

--- a/docs/features/schema/plugins/yoast-seo.md
+++ b/docs/features/schema/plugins/yoast-seo.md
@@ -5,7 +5,7 @@ sidebar_label: Yoast SEO
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/plugins/yoast-seo.md
 description: Describes the schema output of the Yoast SEO plugin for WordPress.
 ---
-import YoastSchemaExample from '../../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 This page documents the [schema.org](https://schema.org/) markup output by the Yoast SEO plugin. More information about our API, integration mechanics, and methodology can be found [here](../overview.md).
 

--- a/docs/features/schema/technology-approach.md
+++ b/docs/features/schema/technology-approach.md
@@ -5,7 +5,7 @@ sidebar_label: Technology & approach
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/schema/technology-approach.md
 description: An overview of some of the technical choices and standards used in our schema.org outputs.
 ---
-import YoastSchemaExample from '../../../../developer-site/src/components/YoastSchemaExample';
+import YoastSchemaExample from '@site/src/components/YoastSchemaExample';
 
 ## JSON-LD as a preferred format
 Structured markup can be implemented in a number of ways, and via a number of different standards. We're particularly interested in the standards defined by [schema.org](https://schema.org/) , given Google's close adherence to their specifications.

--- a/docs/features/seo-tags/meta-robots/overview.md
+++ b/docs/features/seo-tags/meta-robots/overview.md
@@ -10,7 +10,7 @@ This documentation provides technical information about how [Yoast SEO](https://
 ## Resources
 * Our [functional specification](functional-specification.md) describes the logic we use to construct and output meta robots tags in various conditions.
 * Our [API documentation](api.md) [coming soon] provides examples of how technical users and developers can modify the default behavior.
-* You can learn more about the role of meta robots tags in our products on our [feature overview page]() [coming soon].
+* You can learn more about the role of meta robots tags in our products on our [feature overview page](#resources) [coming soon].
 
 ## Further reading
 * ~~Meta robots feature overview~~ [coming soon]

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,6 +2,7 @@
 id: overview
 title: Overview
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/overview.md
+slug: /
 ---
 
 Welcome to the Yoast Developer portal, the place to find any technical information related to our software.

--- a/docs/standards/coding-guidelines-and-principles.md
+++ b/docs/standards/coding-guidelines-and-principles.md
@@ -98,7 +98,7 @@ The [SOLID principles](https://scotch.io/bar-talk/s-o-l-i-d-the-first-five-princ
 
 ### Testing
 
-Whenever writing code, it is important to ensure that it functions in an expected manner. To do this, you should write tests. At Yoast, we use [PHPUnit](https://github.com/sebastianbergmann/phpunit) for PHP and [Jest]() for JavaScript.
+Whenever writing code, it is important to ensure that it functions in an expected manner. To do this, you should write tests. At Yoast, we use [PHPUnit](https://github.com/sebastianbergmann/phpunit) for PHP and [Jest](https://jestjs.io/) for JavaScript.
 
 A few guidelines with regards to testing:
 

--- a/docs/standards/development-setup.md
+++ b/docs/standards/development-setup.md
@@ -4,7 +4,7 @@ title: Standards - Development setup
 sidebar_label: Development setup
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/standards/development-setup.md
 ---
-import Alert from '../../../developer-site/src/components/Alert';
+import Alert from '@site/src/components/Alert';
 
 This page describes the process of how we set up development environments at Yoast.
 

--- a/docs/standards/setting-up-integration-tests-for-the-plugins.md
+++ b/docs/standards/setting-up-integration-tests-for-the-plugins.md
@@ -5,7 +5,7 @@ sidebar_label: Setting up integration tests
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/standards/setting-up-integration-tests-for-the-plugins.md
 description: When running integration tests we have to set up some WordPress Docker containers. This allows us to test against WordPress, which is the 'integration' part.
 ---
-import Alert from '../../../developer-site/src/components/Alert';
+import Alert from '@site/src/components/Alert';
 
 When running integration tests we have to set up some WordPress Docker containers. This allows us to test against WordPress, which is the 'integration' part. An added bonus of this is that you also have a separate setup for writing patches and unit tests.
 

--- a/docs/standards/using-composer.md
+++ b/docs/standards/using-composer.md
@@ -4,7 +4,7 @@ title: Standards - Using Composer
 sidebar_label: Using Composer
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/standards/using-composer.md
 ---
-import Alert from '../../../developer-site/src/components/Alert';
+import Alert from '@site/src/components/Alert';
 
 ## What is Composer?
 [Composer](https://getcomposer.org/) is a dependency manager tool for PHP projects (similar to NPM) and can be run from your terminal.


### PR DESCRIPTION
This PR is two-fold:

* It changes all imports to use an absolute path instead of a relative one, making it much easier to maintain.
* It applies changes necessary for alpha 62 to properly function.

This means that this PR must be tested and merged at the same time as https://github.com/Yoast/developer-site/pull/75