### PR TITLE
Update the published_time meta notes.

### DIFF
--- a/docs/features/opengraph/functional-specification.md
+++ b/docs/features/opengraph/functional-specification.md
@@ -29,7 +29,7 @@ The following tags are only output when their conditions are met:
 | `article:publisher` | The Facebook page URL of the publishing organization. | Only populated when a value has been provided by the user. <br /> Only populated on `post` and `page` types. |
 | `article:author` | The URL of the profile page of the author. | Only populated when the user has a valid profile URL. <br /> Only populated on `post` types. |
 | `article:modified_time` | A timestamp of when the page was last modified. | Only populated on `post` and `page` types. |
-| `article:published_time` | A timestamp of when the page was published. | Only populated on `post` and `page` types. |
+| `article:published_time` | A timestamp of when the page was published. | Only populated on the `post` type. Use the `wpseo_opengraph_show_publish_date` filter to add additional posttypes. |
 | `og:image` | The URL of the primary image of the page. | Only populated when the page contains a valid image, based on the following hierarchy: <ul><li>A user-defined image (for a specific platform).</li><li>A 'featured' image.</li><li>A prominent image from the page's content.</li><li>In the case of an author archive template, the user's Gravatar image.</li><li>The site's fallback/default social image.</li></ul> |
 | `og:image:width` | The width in pixels of the `og:image`. | Only populated when an `og:image` is set, and its width and height are known. |
 | `og:image:height` | The height in pixels of the `og:image`. | Only populated when an `og:image` is set, and its width and height are known. |


### PR DESCRIPTION
The code currently only adds the `published_time` on posts:

```php
	public function generate_open_graph_article_published_time() {
		if ( $this->model->object_sub_type !== 'post' ) {
			/**
			 * Filter: 'wpseo_opengraph_show_publish_date' - Allow showing publication date for other post types.
			 *
			 * @param string $post_type The current URL's post type.
			 *
			 * @api bool Whether or not to show publish date.
			 */
			if ( ! \apply_filters( 'wpseo_opengraph_show_publish_date', false, $this->post->get_post_type( $this->source ) ) ) {
				return '';
			}
		}

		return $this->date->format( $this->source->post_date_gmt );
	}
```

The `wpseo_opengraph_show_publish_date` allows for more posttypes to show this on.