### PR TITLE
Deprecated Facebook App ID references

### DIFF
--- a/docs/customization/apis/metadata-api.md
+++ b/docs/customization/apis/metadata-api.md
@@ -50,7 +50,6 @@ By default, Yoast SEO ships with the following presenters that output meta tags.
 | `Article_Published_Time_Presenter` | `<meta property="article:published_time" content="%s" />` | n/a |
 | `Article_Publisher_Presenter` | `<meta property="article:publisher" content="%s" />` | `wpseo_og_article_publisher` |
 | `Description_Presenter` | `<meta property="og:description" content="%s" />` | `wpseo_opengraph_desc` |
-| `FB_App_ID_Presenter` | `<meta property="fb:app_id" content="%s" />` | n/a |
 | `Locale_Presenter` | `<meta property="og:locale" content="%s" />` | `wpseo_og_locale` |
 | `Site_Name_Presenter` | `<meta property="og:site_name" content="%s" />` | `wpseo_opengraph_site_name` |
 | `Title_Presenter` | `<meta property="og:title" content="%s" />` | `wpseo_opengraph_title` |
@@ -63,6 +62,7 @@ By default, Yoast SEO ships with the following presenters that output meta tags.
 |---|-----|---|--|
 | `Googlebot_Presenter` | `<meta name="googlebot" content="%s" />` | `wpseo_googlebot` | Planned |
 | `Bingbot_Presenter` | `<meta name="bingbot" content="%s" />` | `wpseo_bingbot` | Planned |
+| `FB_App_ID_Presenter` | `<meta property="fb:app_id" content="%s" />` | Yoast SEO 15.5 (Dec 2020) |
 
 ## Editing existing meta tags
 Sometimes you might run into a situation where you want to edit the output of one of the meta tags which are output by Yoast SEO.

--- a/docs/customization/apis/surfaces-api.md
+++ b/docs/customization/apis/surfaces-api.md
@@ -62,7 +62,6 @@ The `current_page` surface exposes every bit of data we have on the current page
 | open_graph_article_published_time | string | The article:published_time value. |
 | open_graph_article_modified_time | string | The article:modified_time value. |
 | open_graph_locale | string | The og:locale for the current page. |
-| open_graph_fb_app_id | string | The Facebook App ID. |
 | schema | array | The entire Schema array for the current page. |
 | twitter_card | string | The Twitter card type for the current page. |
 | twitter_title | string | The Twitter card title for the current page. |
@@ -74,6 +73,11 @@ The `current_page` surface exposes every bit of data we have on the current page
 | breadcrumbs | array | The breadcrumbs array for the current page. |
 
 Whether you need the *OpenGraph description* or the *robots array*, this has you covered. Get used to opening your favorite IDE, typing `YoastSEO()->meta->for_current_page()->` and see the type hints for the exact bit of data you need.
+
+## Deprecated properties
+| Variable | Type | Description | Deprecated |
+| --- | --- | --- |
+| open_graph_fb_app_id | string | The Facebook App ID. | Yoast SEO 15.5 (Dec 2020) |
 
 ## For other pages
 Getting data for any page works in almost exactly the same way as getting data for the current page. You just need to provide an ID, or a URL.

--- a/docs/features/opengraph/functional-specification.md
+++ b/docs/features/opengraph/functional-specification.md
@@ -54,3 +54,4 @@ The following tags used to be output by Yoast SEO, but have been removed in rece
 | `og:image:secure_url` | Defines a (separate) URL for the featured image, available over HTTPS. Unnecessarily duplicates the `og:image` tag when a site is on HTTPS, and, unnecessary/omitted when the site is not. | Yoast SEO v14.0 (Apr 2020) |
 | `og:video:secure_url` | Legacy Facebook / Open Graph tag. As per `og:image:secure_url`, but for the featured video (in our [Video SEO for WordPress plugin](https://yoast.com/wordpress/plugins/video-seo/)). | Yoast SEO v14.0 (Apr 2020) |
 | `og:image:type` | Defines the image format. Poor value/performance trade-off; especially as we ping Facebook on post publish, at which point they determine and cache this information themselves. | Yoast SEO v14.0 (Apr 2020) |
+| `fb:app_id` | The Facebook App ID. | Yoast SEO v15.5 (Dec 2020) |


### PR DESCRIPTION
## Summary
<!--
What does this PR change/introduce?
-->

* Deprecates the references of the Facebook App ID in accordance with https://github.com/Yoast/wordpress-seo/pull/16402.

## Quality assurance

* [ ] I have altered a filename
    * [ ] I have adjusted the ID and editUrl properties accordingly and updated all internal links. 
      The following redirects need to be created:
        * 
    * [ ] I have adjusted the sidebar entry in the [developer-site](https://github.com/Yoast/developer-site) repository
* [x] I have tested my changes

