### PR TITLE
Add post types filter for Duplicate Post

### DIFF
--- a/docs/duplicate-post/filters-actions.md
+++ b/docs/duplicate-post/filters-actions.md
@@ -96,6 +96,30 @@ add_filter( 'duplicate_post_clone_post_link', 'my_custom_clone_post_link' );
 
 Now, any time you call the `duplicate_post_clone_post_link` in your theme, the outputted link will _always_ be wrapped in our custom div tag.
 
+### `duplicate_post_enabled_post_types`
+
+If (for some reason) you need to alter the list of post type for which the plugin is enabled, you can use this filter to do so.
+It is called after the value for the option has been read from the database, so it can be used to override the settings or to enable post types that are not displayed in the Options page.
+
+For example, in either your custom plugin or your theme's `functions.php`, add the following code to enable the plugin for the `product` post type:
+
+```php
+/** 
+ * Enable the plugin for the WooCommerce "product" post type, which is unavailable by default.
+ *
+ * @param array $enabled_post_types The array of post type names for which the plugin is enabled.
+ *
+ * @return array The filtered array of post types names.
+ */
+function my_custom_enabled_post_types( $enabled_post_types ) {
+	$enabled_post_types[] = 'product';
+	return $enabled_post_types;
+}
+add_filter('duplicate_post_enabled_post_types', 'my_custom_enabled_post_types');
+```
+
+Now, any time you call the `duplicate_post_clone_post_link` in your theme, the outputted link will _always_ be wrapped in our custom div tag.
+
 ## Actions
 
 ### `duplicate_post_pre_copy`

--- a/docs/duplicate-post/filters-actions.md
+++ b/docs/duplicate-post/filters-actions.md
@@ -98,7 +98,7 @@ Now, any time you call the `duplicate_post_clone_post_link` in your theme, the o
 
 ### `duplicate_post_enabled_post_types`
 
-If (for some reason) you need to alter the list of post type for which the plugin is enabled, you can use this filter to do so.
+If (for some reason) you need to alter the list of post types for which the plugin is enabled, you can use this filter to do so.
 It is called after the value for the option has been read from the database, so it can be used to override the settings or to enable post types that are not displayed in the Options page.
 
 For example, in either your custom plugin or your theme's `functions.php`, add the following code to enable the plugin for the `product` post type:

--- a/docs/duplicate-post/functions-template-tags.md
+++ b/docs/duplicate-post/functions-template-tags.md
@@ -5,7 +5,7 @@ sidebar_label: Functions & template tags
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/duplicate-post/functions-template-tags.md
 ---
 
-This page contains a list of functions that can be used in template files to interact with Duplicate Posts.
+This page contains a list of functions that can be used in plugins and template files to interact with Duplicate Posts.
 
 ## `duplicate_post_clone_post_link`
 


### PR DESCRIPTION
## Summary
<!--
What does this PR change/introduce?
-->

* In 4.1 we introduced the `duplicate_post_enabled_post_types` filter which needs to be explained.
Also, we need to clarify that not all the functions are template tags (= meant to be used on the front end) - fixes #113 

## Quality assurance

* [ ] I have altered a filename
    * [ ] I have adjusted the ID and editUrl properties accordingly and updated all internal links. 
      The following redirects need to be created:
        * 
    * [ ] I have adjusted the sidebar entry in the [developer-site](https://github.com/Yoast/developer-site) repository
* [ ] I have tested my changes

