### PR TITLE
Update the formatting of `wp_enqueue_script()`

### DIFF
--- a/docs/customization/yoast-seo/filtering-yoast-blocks.md
+++ b/docs/customization/yoast-seo/filtering-yoast-blocks.md
@@ -24,7 +24,14 @@ A better approach to filter out Blocks, is to use a JavaScript implementation. P
 <?php
 // Your plugin code here.
 
-wp_enqueue_script( 'my-custom-blocks-filter', plugins_url( 'js/MyCustomBlocksFilter.js', __FILE__ ), [], '1.0', true );
+wp_enqueue_script( 
+	'my-custom-blocks-filter', 
+	plugins_url( 'js/MyCustomBlocksFilter.js', 
+	__FILE__ ), 
+	[], 
+	'1.0', 
+	true 
+);
 ```
 
 Let's say that you want to only load the FAQ block out of the list of Yoast structured data blocks, and thus want to filter out the How-To block:

--- a/docs/customization/yoast-seo/filtering-yoast-blocks.md
+++ b/docs/customization/yoast-seo/filtering-yoast-blocks.md
@@ -29,7 +29,8 @@ wp_enqueue_script(
 	plugins_url( 'js/MyCustomBlocksFilter.js', __FILE__ ), 
 	[], 
 	'1.0', 
-	true );
+	true 
+);
 ```
 
 Let's say that you want to only load the FAQ block out of the list of Yoast structured data blocks, and thus want to filter out the How-To block:

--- a/docs/customization/yoast-seo/filtering-yoast-blocks.md
+++ b/docs/customization/yoast-seo/filtering-yoast-blocks.md
@@ -26,12 +26,10 @@ A better approach to filter out Blocks, is to use a JavaScript implementation. P
 
 wp_enqueue_script( 
 	'my-custom-blocks-filter', 
-	plugins_url( 'js/MyCustomBlocksFilter.js', 
-	__FILE__ ), 
+	plugins_url( 'js/MyCustomBlocksFilter.js', __FILE__ ), 
 	[], 
 	'1.0', 
-	true 
-);
+	true );
 ```
 
 Let's say that you want to only load the FAQ block out of the list of Yoast structured data blocks, and thus want to filter out the How-To block:


### PR DESCRIPTION
## Summary
Update the formatting of `wp_enqueue_script()` code section in https://developer.yoast.com/customization/yoast-seo/filtering-yoast-blocks.

This removes the overflow of the page due to the length of the code line.

Before

![Screenshot_2021-02-16 Yoast SEO - Filtering Yoast Blocks Yoast Developer portal](https://user-images.githubusercontent.com/33403964/108034644-181c8800-7036-11eb-8b4c-c67ec211ac6f.png)

After

![Screenshot_2021-02-16 Yoast SEO - Filtering Yoast Blocks Yoast Developer portal(1)](https://user-images.githubusercontent.com/33403964/108034654-1f439600-7036-11eb-8208-bdd63a7dbbfa.png)


*

## Quality assurance

* [ ] I have altered a filename
    * [ ] I have adjusted the ID and editUrl properties accordingly and updated all internal links. 
      The following redirects need to be created:
        * 
    * [ ] I have adjusted the sidebar entry in the [developer-site](https://github.com/Yoast/developer-site) repository
* [ ] I have tested my changes

