### PR TITLE
Create deprecations page for Yoast SEO premium

### DIFF
--- a/docs/customization/yoast-seo-premium/deprecations.md
+++ b/docs/customization/yoast-seo-premium/deprecations.md
@@ -1,0 +1,19 @@
+---
+id: api-filter-actions-deprecations
+title: Yoast SEO Premium - Deprecated filters and actions
+sidebar_label: Deprecated filters & actions
+custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/customization/yoast-seo-premium/deprecations.md
+---
+
+We sometimes deprecate filters and actions. In this document we highlight the deprecations and try
+to point you to their replacements.
+
+## Filters and actions deprecated in Yoast SEO Premium 12.9
+
+### Filters
+
+#### `wpseo_premium_post_redirect_slug_change`
+Automatic redirect on page or post slug changes can now be done through the `Yoast\WP\SEO\post_redirect_slug_change` filter.
+
+#### `wpseo_premium_term_redirect_slug_change`
+Automatic redirect on term slug changes can now be done through the `Yoast\WP\SEO\term_redirect_slug_change` filter.


### PR DESCRIPTION
## Summary
Create a page for deprecated filters and actions in Yoast SEO premium.

## Quality assurance

* [X] I have altered a filename
    * [NA] I have adjusted the ID and editUrl properties accordingly and updated all internal links. 
      The following redirects need to be created:
    * [x] I have adjusted the sidebar entry in the [developer-site](https://github.com/Yoast/developer-site) repository
* [x] I have tested my changes

