### PR TITLE
Update filters for automatic redirect creation on slug changes

### DIFF
--- a/docs/customization/yoast-seo-premium/disabling-automatic-redirects-notifications.md
+++ b/docs/customization/yoast-seo-premium/disabling-automatic-redirects-notifications.md
@@ -11,12 +11,12 @@ Yoast SEO Premium monitors for URL changes and automatically creates a redirect.
 
 ### Posts and pages
 ```php
-add_filter( 'wpseo_premium_post_redirect_slug_change', '__return_true' );
+add_filter( 'Yoast\WP\SEO\post_redirect_slug_change', '__return_true' );
 ```
 
 ### Taxonomies (categories, tags etc)
 ```php
-add_filter( 'wpseo_premium_term_redirect_slug_change', '__return_true' );
+add_filter( 'Yoast\WP\SEO\term_redirect_slug_change', '__return_true' );
 ```
 
 Note: If you see the redirect created notification and you have not changed the URL or slug, this is most commonly caused by a conflict. Please check for conflicts by following the steps in [this article](https://yoast.com/kb/how-to-check-for-plugin-conflicts).


### PR DESCRIPTION
## Summary
Update some deprecated filters that automatically creating redirects on slug changes.

## Quality assurance

* [NA] I have altered a filename
    * [NA] I have adjusted the ID and editUrl properties accordingly and updated all internal links. 
      The following redirects need to be created:
    * [NA] I have adjusted the sidebar entry in the [developer-site](https://github.com/Yoast/developer-site) repository
* [X] I have tested my changes

