### PR TITLE
Add docs about title and meta description tags API

### DIFF
--- a/docs/features/seo-tags/descriptions/api.md
+++ b/docs/features/seo-tags/descriptions/api.md
@@ -5,4 +5,27 @@ sidebar_label: API
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/seo-tags/descriptions/api.md
 description: Instructions on how to modify our description values programmatically.
 ---
-Coming soon.
+
+To change the meta description tag that Yoast SEO generated programmatically, you can use the `wpseo_metadesc` filter.
+
+## Change the meta description tag
+For example, the following code would change the meta description on a page with ID `12345`:
+
+```php
+/**
+ * Filters the description.
+ *
+ * @param string $description The current page's generated meta description.
+ *
+ * @return string The filtered meta description.
+ */
+function prefix_filter_description_example( $description ) {
+  if ( is_page( 12345 ) ) {
+    $description = 'My custom custom meta description';
+  }
+
+  return $description;
+}
+
+add_filter( 'wpseo_metadesc', 'prefix_filter_description_example' );
+```

--- a/docs/features/seo-tags/titles/api.md
+++ b/docs/features/seo-tags/titles/api.md
@@ -5,4 +5,27 @@ sidebar_label: API
 custom_edit_url: https://github.com/Yoast/developer-docs/edit/master/docs/features/seo-tags/titles/api.md
 description: Instructions on how to modify our title values programmatically.
 ---
-Coming soon.
+
+To change the title tag that Yoast SEO generated programmatically, you can use the `wpseo_title` filter.
+
+## Change the title tag
+For example, the following code would change the title on a page with ID `12345`:
+
+```php
+/**
+ * Filters the title.
+ *
+ * @param string $title The current page's generated title.
+ *
+ * @return string The filtered title.
+ */
+function prefix_filter_title_example( $title ) {
+  if ( is_page( 12345 ) ) {
+    $title = 'My custom title';
+  }
+
+  return $title;
+}
+
+add_filter( 'wpseo_title', 'prefix_filter_title_example' );
+```


### PR DESCRIPTION
## Summary
<!--
What does this PR change/introduce?
-->

* Adds content for the already existing pages intended for the documentation of the API to filter the title and meta description tags.

## Quality assurance

* [ ] I have altered a filename
    * [ ] I have adjusted the ID and editUrl properties accordingly and updated all internal links. 
      The following redirects need to be created:
        * 
    * [ ] I have adjusted the sidebar entry in the [developer-site](https://github.com/Yoast/developer-site) repository
* [ ] I have tested my changes

