### PR TITLE
ImageObject schema example update

### DIFF
--- a/docs/features/schema/pieces/image.md
+++ b/docs/features/schema/pieces/image.md
@@ -61,7 +61,7 @@ However, Google’s testing tools throw errors in some scenarios when the `url` 
           {
               "@type": "ImageObject",
               "@id": "https://www.example.com/uploads/example-image.jpg",
-              "url": "https://www.example.com/uploads/example-image.jpg"
+              "url": "https://www.example.com/uploads/example-image.jpg",
               "contentUrl": "https://www.example.com/uploads/example-image.jpg"
           }
       ]


### PR DESCRIPTION


## Summary
This was a schema example updat. The url was missing a comma before contentUrl in the example schema under Minimum criteria

*

## Quality assurance

* [ ] I have altered a filename
    * [ ] I have adjusted the ID and editUrl properties accordingly and updated all internal links. 
      The following redirects need to be created:
        * 
    * [ ] I have adjusted the sidebar entry in the [developer-site](https://github.com/Yoast/developer-site) repository
* [ ] I have tested my changes

